### PR TITLE
Add Error Unwrapping & Deprecate Service/Context fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Test Logger
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: NPM Install
+      run: npm install
+
+    - name: Build
+      run: npm run build
+
+    - name: Test
+      run: npm run test

--- a/README.md
+++ b/README.md
@@ -120,19 +120,8 @@ Currently the only logger we have is the `LambdaLogger`.
 
 Once we need another logger it would be good to split this into a generic log class, and specific loggers that extend it.
 
-The `LambdaLogger` will add extra context from the lambda event context.
-
 ```ts
 const log = new LambdaLogger({
-  service: 'image-service',
   level: 'warning'
 });
-
-
-export const handlePostEvent: APIGatewayProxyHandler = (event, context) => {
-  log.setLambdaContext(context);
-
-  return Promise.resolve(result);
-};
-
 ```

--- a/README.md
+++ b/README.md
@@ -73,14 +73,18 @@ log.debug('Debug Message') // ✔️ this will written
 
 See [RFC 5424](https://tools.ietf.org/html/rfc5424).
 
-### Data & Metrics
+### Data, Metrics & Errors
 You can also pass in additional `data` or `metrics` that are relevant to the logs.
+
+You can also pass in an `error` object if you are catching a thrown error somewhere.
 
 `data` must be in a `string: string` format
 
 `metrics` must be in a `string: number` format.
 
-This is so they can be properly auto-indexed by Elastic Search or Datadog.
+`error` can be any error that you catch. It will be unwrapped for you if possible
+
+This is so they can be properly auto-indexed by Elastic Search.
 
 ```ts
 const log = new LambdaLogger({
@@ -88,10 +92,13 @@ const log = new LambdaLogger({
   level: 'warning'
 });
 
+const loginError = new Error('Malformed login request');
+
 log.error('Login Failed!', {
   data: {
     username: 'piesupplies'
-  }
+  },
+  error: loginError
 });
 
 log.warning('Post rate is very high', {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,19 +3,8 @@
 import { LambdaLogger } from '.';
 import mockConsole from 'jest-mock-console';
 
-const context = {
-  functionName: 'function-name',
-  functionVersion: 'function-version',
-  invokedFunctionArn: 'function-arn',
-  memoryLimitInMB: 'function-memory',
-  awsRequestId: 'function-req-id',
-  logGroupName: 'function-log-group-name',
-  logStreamName: 'function-log-stream-name'
-};
-
 describe('LambdaLogger' ,  () => {
   const log = new LambdaLogger({
-    service: 'test',
     logLevel: 'error'
   });
 
@@ -56,9 +45,12 @@ describe('LambdaLogger' ,  () => {
       'user_count': 16
     };
 
+    const testError = new Error('Test Error');
+
     log.error('Error Message', {
       data: expectedData,
-      metrics: expectedMetrics
+      metrics: expectedMetrics,
+      error: testError
     });
 
     const logEntry = JSON.parse(console.error['mock']['calls'][0][0]) ;
@@ -66,6 +58,9 @@ describe('LambdaLogger' ,  () => {
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(logEntry.data).toEqual(expectedData);
     expect(logEntry.metrics).toEqual(expectedMetrics);
+    expect(logEntry.error.message).toEqual(testError.message);
+    expect(logEntry.error.stack).toEqual(testError.stack);
+    expect(logEntry.error.name).toEqual(testError.name);
 
     restoreConsole();
   });
@@ -81,8 +76,6 @@ describe('LambdaLogger' ,  () => {
       'user_count': 16
     };
 
-    log.setLambdaContext(context as any);
-
     log.alert('Alert Message', {
       data: expectedData,
       metrics: expectedMetrics
@@ -93,7 +86,6 @@ describe('LambdaLogger' ,  () => {
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(logEntry.data).toEqual(expectedData);
     expect(logEntry.metrics).toEqual(expectedMetrics);
-    expect(logEntry.awsData.context).toEqual(context);
 
     restoreConsole();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { Context } from 'aws-lambda';
 import shortid from 'shortid';
 
-/** Optional `data` and `metric` values for  @public */
-export type LogOptions = { data?: Log['data']; metrics?: Log['metrics'] };
+/**
+ * Optional `data`, `metric`, and `error` options
+ * @public
+ */
+export type LogOptions = { data?: Log['data']; metrics?: Log['metrics']; error?: any };
 /** @public */
 export type LogFunction = (message: Log['message'], options?: LogOptions) => void;
 type LogWriterFunction = (level: LOG_SEVERITY, message: Log['message'], options?: LogOptions) => void;
@@ -12,8 +15,10 @@ type LogWriterFunction = (level: LOG_SEVERITY, message: Log['message'], options?
  * @public
  */
 export type LoggerConstructorOptions = {
-  service: string;
+  /** @deprecated Service is now pulled from CloudWatch */
+  service?: string;
   logLevel?: string;
+  /** @deprecated Context is now pulled from CloudWatch */
   context?: Context;
 };
 
@@ -74,10 +79,11 @@ export interface Log {
   status: LOG_SEVERITY;
   /**
    * The name of the application or service generating the log events.
+   * @deprecated We pull the stack from the CloudWatch logs directly now
    */
-  service: string;
+  service?: string;
   /**
-   * The message for the error.
+   * The message for the log.
    */
   message: string;
   /**
@@ -90,6 +96,16 @@ export interface Log {
    * with the log. Must be numeric
    */
   metrics: Record<string, number>;
+
+  /**
+   * Specific context related to errors
+   */
+  error?: {
+    message?: string;
+    name?: string;
+    stack?: string;
+    raw?: string;
+  };
   /**
    * A unique id for each
    * logger instance
@@ -106,7 +122,8 @@ export interface Log {
 
 interface LambdaLog extends Log {
   source: 'lambda';
-  awsData: {
+  /** @deprecated Context is now pulled from the CloudWatch logs directly */
+  awsData?: {
     context: {
       functionName?: string;
       functionVersion?: string;
@@ -138,10 +155,8 @@ let logInstance: LambdaLogger;
  */
 export class LambdaLogger {
   private logLevel: LOG_SEVERITY;
-  private service: string;
-  private context?: Context;
 
-  constructor({ service, context = null, logLevel = LOG_WARNING }: LoggerConstructorOptions) {
+  constructor({ logLevel = LOG_WARNING }: LoggerConstructorOptions) {
     if(!logInstance) {
       logInstance = this;
 
@@ -152,8 +167,6 @@ export class LambdaLogger {
       } else {
         this.logLevel = LOG_WARNING;
       }
-      this.service = service;
-      this.context = context;
     }
 
     return logInstance;
@@ -162,9 +175,11 @@ export class LambdaLogger {
   /**
    * Sets the lambda context after
    * the logger has been constructed
+   *
+   * @deprecated Context is now pulled from CloudWatch
    */
   setLambdaContext(context: Context): void {
-    this.context = context;
+    return;
   }
 
   /**
@@ -173,7 +188,7 @@ export class LambdaLogger {
    * current log level
    * @public
    */
-  private writeLog: LogWriterFunction = (level, message, {data= {}, metrics= {}} = {}) => {
+  private writeLog: LogWriterFunction = (level, message, {data= {}, metrics= {}, error} = {}) => {
     // We don't want to write any logs with a higher log level
     if (LogPriority[this.logLevel] < LogPriority[level]) {
       return;
@@ -182,21 +197,9 @@ export class LambdaLogger {
     const logEntry: LambdaLog = {
       source: 'lambda',
       status: level,
-      service: this.service ,
       message: message,
       data: data,
       metrics: metrics,
-      awsData: {
-        context: {
-          functionName: this.context?.functionName,
-          functionVersion: this.context?.functionVersion,
-          invokedFunctionArn: this.context?.invokedFunctionArn,
-          memoryLimitInMB: this.context?.memoryLimitInMB,
-          awsRequestId: this.context?.awsRequestId,
-          logGroupName: this.context?.logGroupName,
-          logStreamName: this.context?.logStreamName
-        }
-      },
       logId: logId,
       process: {
         memoryUsage: process.memoryUsage(),
@@ -205,6 +208,33 @@ export class LambdaLogger {
         versions: process.versions
       },
     };
+
+    // If there's an error we'll attempt to unwrap it
+    if (error) {
+      logEntry.error = {};
+      // If it's an acutal error object we'll extract
+      // the message and the stack
+      if (error instanceof Error) {
+        logEntry.error.message = error.message;
+        logEntry.error.name = error.name;
+        logEntry.error.stack = error.stack;
+        logEntry.error = {
+          message: error.message,
+          name: error.name,
+          stack: error.stack
+        };
+      } else {
+        // Otherwise it could be anything so we'll go ahead and
+        // try to stringify it and add it
+        try {
+          // We'll truncate the full error at 1024 characters as to not
+          // blow up our logs
+          logEntry.error.raw = JSON.stringify(error).substr(0, 512);
+        } catch (jsonStringifyError) {
+          // We don't log inside the logger
+        }
+      }
+    }
 
     switch (level) {
       case LOG_ALERT:

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,11 +218,6 @@ export class LambdaLogger {
         logEntry.error.message = error.message;
         logEntry.error.name = error.name;
         logEntry.error.stack = error.stack;
-        logEntry.error = {
-          message: error.message,
-          name: error.name,
-          stack: error.stack
-        };
       } else {
         // Otherwise it could be anything so we'll go ahead and
         // try to stringify it and add it


### PR DESCRIPTION
## Error Unwrapping.
You can call:
```javascript
const someError = new Error('Validation Error');
Log.error('Unexpected Error', {error: someError});
```
and we'll attempt to unwrap the error for you and add it to the ES logs.

## Service & Context deprecation
We now pull the AWS stack and the context for the function directly from the CloudWatch log, so we don't need to set this any more.

This will eliminate the need to call `Log.setLambdaContext(context);` every time you run a lambda function, which will eliminate some annoying boilerplate.