### PR TITLE
Add Metric Logging and Automatic Facebook Error Unwrapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ log.warning('Post rate is very high', {
 
 ```
 
+### Metrics Only
+Metrics can also be logged directly, with an optional prefix.
+
+This allows you to send metrics to ES for monitoring, no matter what the log level of the logger is set to.
+
+```typescript
+Log.metrics({
+  'image_saved': 5,
+  'image_failed': 0
+}, 'pablo');
+```
 
 ## Specific Loggers
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -90,4 +90,45 @@ describe('LambdaLogger' ,  () => {
     restoreConsole();
   });
 
+  test('Logging Metrics without prefix', () => {
+    const restoreConsole = mockConsole('log');
+
+    const metrics = {
+      'users_saved': 25,
+      'dogs_saved': 962,
+    };
+
+    log.metrics(metrics);
+
+    const logEntry = JSON.parse(console.log['mock']['calls'][0][0]) ;
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(logEntry.metrics).toEqual(metrics);
+
+    restoreConsole();
+  });
+
+  test('Logging Metrics with prefix', () => {
+    const restoreConsole = mockConsole('log');
+
+    const metrics = {
+      'apples': 25,
+      'logYellowApples': 962,
+    };
+
+    const expectedMetrics = {
+      'fruit.apples': 25,
+      'fruit.logYellowApples': 962
+    };
+
+    log.metrics(metrics, 'fruit');
+
+    const logEntry = JSON.parse(console.log['mock']['calls'][0][0]) ;
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(logEntry.metrics).toEqual(expectedMetrics);
+
+    restoreConsole();
+  });
+
 });


### PR DESCRIPTION
This adds direct metric logging to our logger. 

It also adds automatic unwrapping when you pass in a Facebook API Error.